### PR TITLE
Updated us_customary to include usgal

### DIFF
--- a/lib/unit_measurements/unit_groups/volume.rb
+++ b/lib/unit_measurements/unit_groups/volume.rb
@@ -52,6 +52,7 @@ UnitMeasurements::Volume = UnitMeasurements.build do
   system :us_customary do
     unit "cd", value: "128 ft³", aliases: ["cord", "cords"]
 
+    unit "usgal", value: "3.785411784 dm³", alias: ["us-gallon", "us-gal"]
     unit "pot", value: "2 qt", aliases: ["pottle", "pottles"]
     unit "bdft", value: "144 in³", aliases: ["bf", "fbm", "board-foot", "board-feet"]
 

--- a/lib/unit_measurements/unit_groups/volume.rb
+++ b/lib/unit_measurements/unit_groups/volume.rb
@@ -52,7 +52,7 @@ UnitMeasurements::Volume = UnitMeasurements.build do
   system :us_customary do
     unit "cd", value: "128 ft³", aliases: ["cord", "cords"]
 
-    unit "usgal", value: "3.785411784 dm³", alias: ["us-gallon", "us-gal"]
+    unit "usgal", value: "3.785411784 dm³", aliases: ["us-gallon", "us-gal"]
     unit "pot", value: "2 qt", aliases: ["pottle", "pottles"]
     unit "bdft", value: "144 in³", aliases: ["bf", "fbm", "board-foot", "board-feet"]
 


### PR DESCRIPTION
using the acceptable conversion of 1 US gal is 3.785411784 dm³ , this will allow conversion of Litres to US Gallons which will help with measurements between US and places that use the Metric system.